### PR TITLE
Decrement the id when a renderable is removed

### DIFF
--- a/glitz.js
+++ b/glitz.js
@@ -585,7 +585,7 @@
       removeChild: function( removingChild ){
         Array.prototype.splice.call( this, removingChild._id, 1)
         each(this,function( child ){ 
-          if(child._id > removingChild._id) child._id++
+          if(child._id > removingChild._id) child._id--
         })
       },
       


### PR DESCRIPTION
When a renderable is removed from the layout, the ._id should be
decremented instead of incremented.
